### PR TITLE
[TIDESK-665] Don't prevent exit of application on OS X.

### DIFF
--- a/modules/ti.UI/mac/TitaniumApplicationDelegate.mm
+++ b/modules/ti.UI/mac/TitaniumApplicationDelegate.mm
@@ -87,8 +87,11 @@
 
 -(NSApplicationTerminateReply) applicationShouldTerminate:(NSApplication*)sender
 {
-    kroll::Host::GetInstance()->Exit(0);
-    return NO;
+    // If the exit is aborted, prevent the application from exiting.
+    if (!kroll::Host::GetInstance()->Exit(0))
+        return NSTerminateCancel;
+
+    return NSTerminateNow;
 }
 
 @end


### PR DESCRIPTION
The application will only abort the exit if one of the event
listeners cancels it. This resolves the issue where shutting down
a system running a Titanium application aborts the operation.
