### PR TITLE
[TIDESK-688] Fix Web Storage on Mac OS X

### DIFF
--- a/modules/ti.UI/mac/WebViewDelegate.mm
+++ b/modules/ti.UI/mac/WebViewDelegate.mm
@@ -51,16 +51,6 @@ using namespace Titanium;
 
     [[window webView] setPreferences:webPrefs];
     [webPrefs release];
-
-
-    // Store Web databases in our data directory.
-    NSString* datadir = [NSString stringWithUTF8String:
-        Host::GetInstance()->GetApplication()->GetDataPath().c_str()];
-    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
-    [defaults setObject:datadir forKey:@"WebDatabaseDirectory"];
-    [defaults setObject:datadir forKey:@"WebKitLocalStorageDatabasePathPreferenceKey"];
-    [defaults setObject:datadir forKey:@"WebKitLocalCache"];
-    [defaults synchronize];
 }
 
 -(id)initWithWindow:(NativeWindow*)inWindow

--- a/modules/ti.UI/mac/WebViewDelegate.mm
+++ b/modules/ti.UI/mac/WebViewDelegate.mm
@@ -54,14 +54,13 @@ using namespace Titanium;
 
 
     // Store Web databases in our data directory.
-    // XXX(josh): does this work?
     NSString* datadir = [NSString stringWithUTF8String:
         Host::GetInstance()->GetApplication()->GetDataPath().c_str()];
-    NSUserDefaults* standardUserDefaults = [NSUserDefaults standardUserDefaults];
-    [standardUserDefaults
-        setObject:datadir
-        forKey:@"WebDatabaseDirectory"];
-    [standardUserDefaults synchronize];
+    NSUserDefaults* defaults = [NSUserDefaults standardUserDefaults];
+    [defaults setObject:datadir forKey:@"WebDatabaseDirectory"];
+    [defaults setObject:datadir forKey:@"WebKitLocalStorageDatabasePathPreferenceKey"];
+    [defaults setObject:datadir forKey:@"WebKitLocalCache"];
+    [defaults synchronize];
 }
 
 -(id)initWithWindow:(NativeWindow*)inWindow


### PR DESCRIPTION
This should resolve the issue with local storage not persisting between application
sessions on Mac OS X. Fixed by setting a preference which tells WebKit where to locate
the database used for storage.
