### PR TITLE
removeProperty doesn't work

### DIFF
--- a/modules/ti.App/Properties.cpp
+++ b/modules/ti.App/Properties.cpp
@@ -261,6 +261,9 @@ void Properties::RemoveProperty(const ValueList& args, KValueRef result)
 {
     args.VerifyException("removeProperty", "s");
     result->SetBool(config->removeProperty(args.GetString(0)));
+    if (result) {
+        this->SaveConfig();
+    }
 }
 
 void Properties::ListProperties(const ValueList& args, KValueRef result)


### PR DESCRIPTION
See description & sample application which reproduces the bug at http://jira.appcelerator.org/browse/TC-299. The root of the bug is 'removeProperty' doesn't flush the new config to the application.properties file.
