### PR TITLE
Volume/device attachment and removal events

### DIFF
--- a/modules/ti.UI/win/UserWindowWin.cpp
+++ b/modules/ti.UI/win/UserWindowWin.cpp
@@ -23,6 +23,7 @@
 #include <comutil.h>
 #include <shellapi.h>
 #include <shlobj.h>
+#include <dbt.h>
 
 #include "MenuItemWin.h"
 #include "MenuWin.h"
@@ -194,6 +195,20 @@ static LRESULT CALLBACK UserWindowWndProc(HWND hWnd, UINT message, WPARAM wParam
             else
             {
                 handled = MenuItemWin::HandleClickEvent(nativeMenu, position);
+            }
+        }
+        break;
+        case WM_DEVICECHANGE:
+        {
+            const char *evt = "volume.added";
+            switch(wParam)
+            {
+              case DBT_DEVICEREMOVECOMPLETE:
+                evt = "volume.removed";
+              case DBT_DEVICEARRIVAL:
+                PDEV_BROADCAST_HDR dev = (PDEV_BROADCAST_HDR)lParam;
+                if (dev->dbch_devicetype == DBT_DEVTYP_VOLUME)
+                    GlobalObject::GetInstance()->FireEvent(evt);
             }
         }
         break;


### PR DESCRIPTION
This adds platform-specific code to fire global "volume.added" and "volume.removed" events when removable devices containing filesystems are attached or ejected/removed. One event is fired per device, rather than per filesystem, and no specific information about the device(s) in question is provided.

I have added these same simple, you might say crude, system-related events to this branch for Windows and to the master branch with a similar implementation for Mac. Rather than providing a full device/volume information API, we have found simply being notified that some kind of change has occurred very useful in our application, with further platform-specific code that it may not be worth lumbering the SDK with being used in response to these events to identify and examine the devices of interest, such as USB flash drives.

Though this may not seem very polished or broadly useful, it would be useful to have this small additional feature incorporated in the official SDK, particularly on Windows where it is by far easiest to get this information from the message pumping code of the main application window than to achieve the same without it.

Thank you for considering this submission.
