### PR TITLE
Volume/device attachment and removal events

### DIFF
--- a/modules/ti.UI/SConscript
+++ b/modules/ti.UI/SConscript
@@ -29,7 +29,7 @@ elif build.is_win32():
 
 elif build.is_osx():
     env.Append(FRAMEWORKPATH=[build.tp('growl')])
-    env.Append(FRAMEWORKS=['Cocoa','Carbon', 'IOKit', 'Growl'])
+    env.Append(FRAMEWORKS=['Cocoa','Carbon', 'IOKit', 'Growl', 'DiskArbitration'])
     sources = sources + Glob('mac/*.mm') + Glob('mac/*.cpp')
     env.Append(CCFLAGS=['-x', 'objective-c++'])
 

--- a/modules/ti.UI/mac/UIMac.h
+++ b/modules/ti.UI/mac/UIMac.h
@@ -73,6 +73,7 @@ protected:
     NSObject* application;
     AutoPtr<MenuMac> activeMenu;
     AutoPtr<UserWindowMac> activeWindow;
+    DASessionRef session;
 
     void InstallMenu (MenuItemMac*);
 };


### PR DESCRIPTION
This adds platform-specific code to fire global "volume.added" and "volume.removed" events when removable devices containing filesystems are attached or ejected/removed. One event is fired per device, rather than per filesystem, and no specific information about the device(s) in question is provided.

I have added these same simple, you might say crude, system-related events to this branch for OS X and to the v1.2-windows branch with a similar implementation for Windows. Rather than providing a full device/volume information API, we have found simply being notified that some kind of change has occurred very useful in our application, with further platform-specific code that it may not be worth lumbering the SDK with being used in response to these events to identify and examine the devices of interest, such as USB flash drives.

The `DiskDescriptionChanged` callback is used, with the `VolumePath` property being monitored, instead of the `DiskAppeared` callback, to provide the event at a time when the volume has been mounted ready for use in the application. Disks without partitions and/or volumes or volumes that do not get mounted would be filtered by the code in `report_disk` anyway, which also filter out readonly, network and fixed-disk volumes, as this has been geared for an application wishing to manipulate removable storage devices. A more full API for disk information and notification would of course need the flexibility for such filters to be choosen by the application and in a platform-neutral way, but I think may be a useful interim for a variety of projects.

Thank you for considering this submission.
