### PR TITLE
basic async support in Titanium.Network.createHTTPServer

### DIFF
--- a/modules/ti.Network/HTTPServerResponse.cpp
+++ b/modules/ti.Network/HTTPServerResponse.cpp
@@ -35,6 +35,7 @@ HTTPServerResponse::HTTPServerResponse(Poco::Net::HTTPServerResponse &response)
     SetMethod("addCookie",&HTTPServerResponse::AddCookie);
     SetMethod("setHeader",&HTTPServerResponse::SetHeader);
     SetMethod("write",&HTTPServerResponse::Write);
+    SetMethod("enableAsync",&HTTPServerResponse::EnableAsync);
 }
 
 void HTTPServerResponse::SetStatus(const ValueList& args, KValueRef result)
@@ -102,6 +103,7 @@ void HTTPServerResponse::SetHeader(const ValueList& args, KValueRef result)
 void HTTPServerResponse::Write(const ValueList& args, KValueRef result)
 {
     std::ostream& ostr = response.send();
+    asyncState = -1;
     
     if (args.at(0)->IsString())
     {
@@ -120,6 +122,16 @@ void HTTPServerResponse::Write(const ValueList& args, KValueRef result)
     else
     {
         throw ValueException::FromString("Don't know how to write that kind of data.");
+    }
+}
+
+void HTTPServerResponse::EnableAsync(const ValueList& args, KValueRef result)
+{
+    if (asyncState >= 0) {
+        //int v = args.at(0)->ToInt();
+        asyncState = 1;
+    } else {
+        throw ValueException::FromString("response already written, no async allowed.");
     }
 }
 

--- a/modules/ti.Network/HTTPServerResponse.h
+++ b/modules/ti.Network/HTTPServerResponse.h
@@ -25,7 +25,7 @@ namespace Titanium {
 class HTTPServerResponse : public StaticBoundObject {
 public:
     HTTPServerResponse(Poco::Net::HTTPServerResponse &response);
-    
+    int asyncState; //0:sync & waiting for response; 1:async & waiting for response; -1: got response
 private:
     void SetStatus(const ValueList& args, KValueRef result);
     void SetReason(const ValueList& args, KValueRef result);
@@ -35,6 +35,7 @@ private:
     void AddCookie(const ValueList& args, KValueRef result);
     void SetHeader(const ValueList& args, KValueRef result);
     void Write(const ValueList& args, KValueRef result);
+    void EnableAsync(const ValueList& args, KValueRef result);
 
     Poco::Net::HTTPServerResponse& response;
 };

--- a/modules/ti.UI/mac/MenuDelegate.h
+++ b/modules/ti.UI/mac/MenuDelegate.h
@@ -18,7 +18,7 @@
 
 #include "MenuMac.h"
 
-@interface MenuDelegate : NSObject
+@interface MenuDelegate : NSObject<NSMenuDelegate>
 {
     Titanium::MenuMac* menu;
     BOOL dirty;

--- a/modules/ti.UI/mac/NativeWindow.h
+++ b/modules/ti.UI/mac/NativeWindow.h
@@ -31,7 +31,7 @@ class UserWindowMac;
 
 @class WebViewDelegate;
 
-@interface NativeWindow : NSWindow
+@interface NativeWindow : NSWindow<NSWindowDelegate>
 {
     BOOL canReceiveFocus;
     WebView* webView;

--- a/modules/ti.UI/mac/TitaniumApplicationDelegate.h
+++ b/modules/ti.UI/mac/TitaniumApplicationDelegate.h
@@ -18,7 +18,7 @@
 
 #include "UIMac.h"
 
-@interface TitaniumApplicationDelegate : NSObject
+@interface TitaniumApplicationDelegate : NSObject<NSApplicationDelegate>
 {
     Titanium::UIMac *binding;
 }


### PR DESCRIPTION
call response.enableAsync() will allow response to be written a while after the server callback is returned.

```
var httpServer = Titanium.Network.createHTTPServer();
httpServer.bind(8080, function(request, response)
{
    Titanium.API.debug("Got request for URI: " + request.getURI());
    response.setContentType("text/html");
    if (request.getURI().match(/async/)) {
        response.enableAsync(); // NOTE response.write() can only be invoked once.
        setTimeout(function(){
            response.write("<h1>Hello from Async</h1>");
        }, 1000);
    } else {
        response.write("<h1>Hello!</h1>");
    }
});
```
